### PR TITLE
Fix fallback image URL resolution after redirects

### DIFF
--- a/src/core/scrape.ts
+++ b/src/core/scrape.ts
@@ -1,5 +1,6 @@
 import { load as loadHtml } from 'cheerio';
 import { fetch } from 'undici';
+import type { Response } from 'undici';
 import { extractBasic, extractFallbackImages, extractOg, extractTwitter } from './extract';
 import type { ScrapeOptions, ScrapeResult } from '../types';
 import { ScrapeError } from '../types';
@@ -10,8 +11,8 @@ export async function scrape(url: string, opts: ScrapeOptions = {}): Promise<Scr
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeout);
 
-  const ua = opts.userAgent ?? 'imediatoeratorBot/0.1 (+https://example.com)';
-  let res;
+  const ua = opts.userAgent ?? 'imediato-scraper/0.1 (+https://example.com)';
+  let res: Response;
   try {
     res = await fetch(url, { signal: controller.signal, headers: { 'user-agent': ua, accept: 'text/html,*/*' } });
   } catch (err) {
@@ -40,7 +41,7 @@ export async function scrape(url: string, opts: ScrapeOptions = {}): Promise<Scr
   const depth = opts.depth ?? 'fast';
   const useFallbackImgs = depth !== 'fast' && !(og.image?.length) && !(twitter.image);
   const fallback = {
-    images: useFallbackImgs ? extractFallbackImages($, url) : undefined
+    images: useFallbackImgs ? extractFallbackImages($, res.url) : undefined
   };
 
   const srcMap: Record<'title' | 'description' | 'image', 'og' | 'twitter' | 'basic' | 'fallback' | 'none'> = {

--- a/src/scrape.test.ts
+++ b/src/scrape.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { scrape } from './index';
+
+// Test that fallback images are resolved against the final URL after redirects
+// to ensure relative image paths are correct even when the initial URL redirects.
+describe('scrape', () => {
+  it('uses final URL when resolving fallback images', async () => {
+    const server = createServer((req, res) => {
+      if (req.url === '/start') {
+        res.writeHead(302, { Location: '/new/index.html' });
+        res.end();
+      } else if (req.url === '/new/index.html') {
+        res.setHeader('Content-Type', 'text/html');
+        res.end('<html><body><img src="image.png" /></body></html>');
+      } else {
+        res.statusCode = 404;
+        res.end();
+      }
+    });
+
+    await new Promise<void>(resolve => server.listen(0, resolve));
+    const { port } = server.address() as AddressInfo;
+
+    const result = await scrape(`http://localhost:${port}/start`, { depth: 'deep' });
+    server.close();
+
+    expect(result.meta.fallback.images).toEqual([
+      `http://localhost:${port}/new/image.png`
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure fallback images resolve against final URL instead of the original request
- correct default user-agent string
- add regression test for redirect image resolution

## Testing
- `pnpm lint`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68aac8d5d468832b9245ed3650ea30e5